### PR TITLE
FlipKart Example Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@
 
 ## Running Tests
 1. Ensure you have Selenium Standalone Server running.
-2. `vendor/bin/mftf run:test SamplePwaTest`
+2. Run Sample Tests:
+    * `vendor/bin/mftf run:test SamplePwaTest`
+    * `vendor/bin/mftf run:test FlipKartSampleTest`

--- a/app/code/Magento/Pwa/Test/Mftf/Data/SampleCustomerData.xml
+++ b/app/code/Magento/Pwa/Test/Mftf/Data/SampleCustomerData.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:DataGenerator/etc/dataProfileSchema.xsd">
+    <entity name="SampleCustomer" type="customer">
+        <data key="email" unique="prefix">test@test.com</data>
+        <data key="phoneNumber">9190897865</data>
+    </entity>
+</entities>

--- a/app/code/Magento/Pwa/Test/Mftf/Section/FlipKartStorefrontCheckoutPageSection.xml
+++ b/app/code/Magento/Pwa/Test/Mftf/Section/FlipKartStorefrontCheckoutPageSection.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="StorefrontCheckoutPage">
+        <element name="emailAddress" type="textarea" selector="//a[contains(@href, '/login')]/../..//input"/>
+        <element name="phoneNumber" type="textarea" selector="//label[contains(., 'Enter Mobile number')]/..//input"/>
+        <element name="continueButton" type="textarea" selector="//button[contains(., 'CONTINUE')]"/>
+    </section>
+</sections>

--- a/app/code/Magento/Pwa/Test/Mftf/Section/FlipKartStorefrontHomepageSection.xml
+++ b/app/code/Magento/Pwa/Test/Mftf/Section/FlipKartStorefrontHomepageSection.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="StorefrontHomepage">
+        <element name="loginModelX" type="button" selector="//button[contains(., '✕')]"/>
+        <element name="livPureProduct" type="button" selector=".required-tracking a[title='{{var1}}']" parameterized="true"/>
+    </section>
+</sections>

--- a/app/code/Magento/Pwa/Test/Mftf/Section/FlipKartStorefrontProductPageSection.xml
+++ b/app/code/Magento/Pwa/Test/Mftf/Section/FlipKartStorefrontProductPageSection.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="StorefrontProductPage">
+        <element name="addToCart" type="button" selector="//button[contains(., 'ADD TO CART')]"/>
+    </section>
+</sections>

--- a/app/code/Magento/Pwa/Test/Mftf/Section/FlipKartStorefrontShoppingCartSection.xml
+++ b/app/code/Magento/Pwa/Test/Mftf/Section/FlipKartStorefrontShoppingCartSection.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="StorefrontShoppingCart">
+        <element name="increaseQtyButton" type="button" selector="//button[contains(., '+')]"/>
+        <element name="productQtyField" type="textarea" selector="//button[contains(., '+')]/../..//input"/>
+        <element name="placeOrderButton" type="button" selector="//button[contains(., 'Place Order')]"/>
+    </section>
+</sections>

--- a/app/code/Magento/Pwa/Test/Mftf/Test/FlipKartNavigateToCheckoutPageTest.xml
+++ b/app/code/Magento/Pwa/Test/Mftf/Test/FlipKartNavigateToCheckoutPageTest.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="NavigateToCheckoutPageTest">
+        <annotations>
+            <stories value="Navigation"/>
+            <title value="Store Navigation"/>
+            <description value="You should be able to navigate around the Store."/>
+            <testCaseId value="#"/>
+            <severity value="MINOR"/>
+            <group value="pwa"/>
+        </annotations>
+        
+        <before>
+            <amOnUrl url="https://www.flipkart.com/" stepKey="amOnStorefront1"/>
+            <wait time="5" stepKey="wait1"/>
+            <seeInCurrentUrl url="https://www.flipkart.com/" stepKey="seeInCurrentUrl1"/>
+        </before>
+
+        <click selector="{{StorefrontHomepage.loginModelX}}" stepKey="closeLoginModel1"/>
+        <wait time="5" stepKey="wait1"/>
+        <click selector="{{StorefrontHomepage.livPureProduct('Livpure')}}" stepKey="clickOnProductLivePure1"/>
+        <wait time="5" stepKey="wait2"/>
+        <seeInCurrentUrl url="livpure-annual-maintenance-contract" stepKey="seeInCurrentUrl2"/>
+
+        <click selector="{{StorefrontProductPage.addToCart}}" stepKey="clickAddToCart1"/>
+        <wait time="5" stepKey="wait3"/>
+        <seeInCurrentUrl url="GoToCart" stepKey="seeInCurrentUrl3"/>
+
+        <click selector="{{StorefrontShoppingCart.increaseQtyButton}}" stepKey="clickOnIncreaseProductQty1"/>
+        <wait time="5" stepKey="wait4"/>
+        <see userInput="We're sorry! Only 1 units of Livpure Annual Maintenance Contract for each customer." stepKey="seeErrorMessageOnPage1"/>
+        <seeInField userInput="1" selector="{{StorefrontShoppingCart.productQtyField}}" stepKey="seeQtyInProductQtyField1"/>
+
+        <click selector="{{StorefrontShoppingCart.placeOrderButton}}" stepKey="clickOnPlageOrderButton1"/>
+        <wait time="5" stepKey="wait5"/>
+
+        <fillField selector="{{StorefrontCheckoutPage.emailAddress}}" userInput="{{SampleCustomer.email}}" stepKey="fillCustomerFirstNameField1"/>
+        <click selector="{{StorefrontCheckoutPage.continueButton}}" stepKey="clickOnContinueButton1"/>
+        <wait time="5" stepKey="wait6"/>
+
+        <fillField selector="{{StorefrontCheckoutPage.phoneNumber}}" userInput="{{SampleCustomer.phoneNumber}}" stepKey="fillCustomerPhoneNumberField1"/>
+        <click selector="{{StorefrontCheckoutPage.continueButton}}" stepKey="clickOnContinueButton2"/>
+        <wait time="5" stepKey="wait7"/>
+
+        <!-- PLEASE NOTE: This is as far as we can get on the following PWA site. -->
+        <!-- Additional fields are only available AFTER you verify the Phone Number that you entered. -->
+    </test>
+</tests>

--- a/app/code/Magento/Pwa/Test/Mftf/Test/FlipKartSampleTest.xml
+++ b/app/code/Magento/Pwa/Test/Mftf/Test/FlipKartSampleTest.xml
@@ -8,7 +8,7 @@
 
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
-    <test name="NavigateToCheckoutPageTest">
+    <test name="FlipKartSampleTest">
         <annotations>
             <stories value="Navigation"/>
             <title value="Store Navigation"/>


### PR DESCRIPTION
- Adding a Test for the FlipKart PWA website.
    + I created a Test for a popular PWA site to test a more robust PWA site.
    + PLEASE NOTE: This test contains hardcoded `<wait/>`'s since the `<waitForPageLoad/>` function does not work with PWAs. 
- Adding necessary Section Objects and Data for the test.