### PR TITLE
Fix "GuestIsAbleToAccessCategories" test

### DIFF
--- a/app/code/Magento/Pwa/Test/Mftf/ActionGroup/VeniaCategoryActionGroup.xml
+++ b/app/code/Magento/Pwa/Test/Mftf/ActionGroup/VeniaCategoryActionGroup.xml
@@ -24,13 +24,9 @@
     <actionGroup name="OpenStorefrontCategoryByName">
         <arguments>
             <argument name="categoryName" defaultValue="ShopTheLook"/>
-            <argument name="productName" defaultValue="ValeriaTwoLayerTank"/>
         </arguments>
         <click userInput="{{categoryName.name}}" stepKey="clickOnCategoryName1"/>
         <waitForPwaElementNotVisible selector="{{VeniaStorefrontSection.productImage(categoryName.name)}}"  stepKey="waitForPwaElementNotVisible01"/>
-        <waitForPwaElementVisible selector="{{VeniaCategorySection.productImageAlt(productName.name)}}" stepKey="waitForPwaElementVisible01"/>
-        <wait time="5" stepKey="temporaryStaticWait1" />
-        <see selector="{{productName.name}}" stepKey="assertProductIsVisible"/>
     </actionGroup>
 
     <actionGroup name="OpenMainMenuCategoryByName">
@@ -56,10 +52,13 @@
 
     <actionGroup name="AssertProductDisplay">
         <arguments>
-            <argument name="productName" defaultValue="ValeriaTwoLayerTank"/>
+            <argument name="categoryDisplayName" type="string"/>
         </arguments>
-        <waitForPwaElementVisible selector="{{VeniaCategorySection.productImageAlt(productName.name)}}" stepKey="waitForPwaElementVisible01"/>
-        <see userInput="{{productName.name}}" stepKey="seeProductName"/>
+        <wait time="5" stepKey="temporaryStaticWait"/>
+        <seeElement selector="{{VeniaCategorySection.categoryTitle(categoryDisplayName)}}" stepKey="assertcategoryTitleexists"/>
+        <seeElement selector="{{VeniaCategorySection.filterButton}}" stepKey="assertFilterButtonExists"/>
+        <seeElement selector="{{VeniaCategorySection.sortButton}}" stepKey="assertSortButtonExists"/>
+        <seeElement selector="{{VeniaCategorySection.galleryItems}}" stepKey="assertProductContainerExists"/>
     </actionGroup>
 
 

--- a/app/code/Magento/Pwa/Test/Mftf/Section/VeniaCategorySection.xml
+++ b/app/code/Magento/Pwa/Test/Mftf/Section/VeniaCategorySection.xml
@@ -14,5 +14,9 @@
         <element name="productName" type="text" selector="[class*='item-name-'] span"/>
         <element name="productNameLink" type="button" selector="//*[contains(@class, 'item-name-')]/span[contains(text(), '{{var1}}')]" parameterized="true"/>
         <element name="productPrice" type="text" selector="[class*='item-price-']"/>
+        <element name="categoryTitle" type="text" selector="//div[contains(text(), '{{categoryName}}')]" parameterized="true"/>
+        <element name="filterButton" type="button" selector="//button[contains(text(), 'Filter')]"/>
+        <element name="sortButton" type="button" selector="//button[contains(text(), 'Sort')]"/>
+        <element name="galleryItems" type="text" selector="div[class*='gallery-items-']"/>
     </section>
 </sections>

--- a/app/code/Magento/Pwa/Test/Mftf/Test/VeniaGuestIsAbleToAccessCategories.xml
+++ b/app/code/Magento/Pwa/Test/Mftf/Test/VeniaGuestIsAbleToAccessCategories.xml
@@ -30,18 +30,22 @@
             <argument name="categoryName" value="Bottoms"/>
         </actionGroup>
         <actionGroup ref="AssertProductDisplay" stepKey="assertProductsDisplay">
-            <argument name="productName" value="IsadoraSkirt"/>
+            <argument name="categoryDisplayName" value="Skirts"/>
         </actionGroup>
 
         <actionGroup ref="GoToVeniaDesktopStorefront" stepKey="goToVeniaDesktopStorefront2"/>
 
         <actionGroup ref="OpenMainMenuCategoryByName" stepKey="openCategoryFromMainMenu1"/>
         <actionGroup ref="OpenMainMenuSubCategoryByName" stepKey="openSubCategoryFromMainMenu1"/>
-        <actionGroup ref="AssertProductDisplay" stepKey="assertProductsDisplay1"/>
+        <actionGroup ref="AssertProductDisplay" stepKey="assertProductsDisplay2">
+            <argument name="categoryDisplayName" value="Minimalist Sensibility"/>
+        </actionGroup>
 
         <actionGroup ref="GoToVeniaDesktopStorefront" stepKey="goToVeniaDesktopStorefront3"/>
 
         <actionGroup ref="OpenStorefrontCategoryByName" stepKey="openStorefrontCategoryByName1"/>
-
+        <actionGroup ref="AssertProductDisplay" stepKey="assertProductsDisplay3">
+            <argument name="categoryDisplayName" value="Shop The Look"/>
+        </actionGroup>
     </test>
 </tests>


### PR DESCRIPTION
After implementing Sort feature, now product displayed in each category is server driven "Best Match".   Updated assert method for category product display.  Also added, assert for Filter and Sort button display.

Verification - 
1. `vendor/bin/mftf run:test GuestIsAbleToAccessCategorie` should pass.
2. `vendor/bin/mftf run:group PWA` should Pass
3. `vendor/bin/mftf run:test GuestIsAbleToAccessCategorie` should fail if wrong Category name is displayed.  Just update value of below line to something else to test this -app/code/Magento/Pwa/Test/Mftf/Test/VeniaGuestIsAbleToAccessCategories.xml:48